### PR TITLE
Fix overshoot issue in F.to_pil_image

### DIFF
--- a/torchvision/transforms/functional.py
+++ b/torchvision/transforms/functional.py
@@ -245,7 +245,7 @@ def to_pil_image(pic, mode=None):
     npimg = pic
     if isinstance(pic, torch.Tensor):
         if pic.is_floating_point() and mode != 'F':
-            pic = pic.mul(255).byte()
+            pic = pic.mul(255).round().clamp(0, 1).byte()
         npimg = np.transpose(pic.cpu().numpy(), (1, 2, 0))
 
     if not isinstance(npimg, np.ndarray):


### PR DESCRIPTION
When converting a tensor to a PIL image, overshoots are not clamped. This means that a value of 1.001 becomes 0 instead of 255. This issue is described here: https://github.com/pytorch/vision/issues/2950#issuecomment-722070283
Additionally, replace the imprecise truncation by a rounding.
Both issues are particularly annoying for downsampling/upsampling code, where such overshoots are common.